### PR TITLE
docker: do not expose port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     image: ghcr.io/${GITHUB_REPOSITORY:-owner/repo}:latest
     container_name: plachtis-web
     restart: unless-stopped
-    ports:
-      - "8000:8000"
     environment:
       - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
       - DJANGO_DEBUG=False


### PR DESCRIPTION
The reverse proxy handles everything. Our container should not expose ports.