### PR TITLE
Remove registration/editing deadline for organizers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,8 @@ AttendanceLog (event attendance tracking)
 
 Ownership is tracked via `Entity.created_by`. Editors can be delegated via `Entity.editors` (ManyToMany). Key model methods: `can_be_edited()`, `can_manage_editors()`, `is_owner()`. After registration deadline, edits are blocked unless `Entity.unlocked_for_editing=True`.
 
+**Deadline exemptions**: Organizer registration and editing are intentionally exempt from `registration_deadline` and `editing_deadline` — organizers can register and edit at any time (issue #124).
+
 ### Key Patterns
 
 - **Singleton settings**: `EventSettings.get_solo()` via `django-solo`; controls `is_registration_open()` / `is_editing_open()`

--- a/SkaRe/tests/test_organizer_views.py
+++ b/SkaRe/tests/test_organizer_views.py
@@ -1,0 +1,82 @@
+from datetime import date, timedelta
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.utils import timezone
+from SkaRe.models import Entity, Organizer, EventSettings
+
+
+def _make_organizer(user):
+    entity = Entity.objects.create(
+        created_by=user, contact_email='o@example.com', contact_phone='+420777000000',
+    )
+    return Organizer.objects.create(
+        entity=entity, first_name='Org', last_name='User',
+        date_of_birth=date(1980, 1, 1),
+    )
+
+
+class OrganizerRegistrationDeadlineTest(TestCase):
+    """Organizer registration must not be blocked by the registration deadline (issue #124)."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username='owner', password='pw')
+        self.client.login(username='owner', password='pw')
+
+        # Close registration deadline
+        settings = EventSettings.get_solo()
+        settings.registration_deadline = timezone.now() - timedelta(hours=1)
+        settings.save()
+
+    def test_register_organizer_allowed_after_deadline(self):
+        url = reverse('SkaRe:register_organizer')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_register_organizer_post_allowed_after_deadline(self):
+        url = reverse('SkaRe:register_organizer')
+        # GET first to generate a form token in the session
+        get_response = self.client.get(url)
+        form_token = self.client.session.get('form_token', '')
+        data = {
+            'first_name': 'Jan',
+            'last_name': 'Novák',
+            'date_of_birth': '1990-01-01',
+            'contact_email': 'jan@example.com',
+            'contact_phone': '+420123456789',
+            'division': 'OTHERS',
+            'transport': 'PUBLIC',
+            'accommodation': 'OWN_TENT',
+            'codex_agreement': True,
+            'form_token': form_token,
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(Organizer.objects.count(), 1)
+        self.assertRedirects(response, reverse('SkaRe:home'))
+
+    def test_register_organizer_page_has_no_deadline_info(self):
+        url = reverse('SkaRe:register_organizer')
+        response = self.client.get(url)
+        self.assertNotContains(response, 'Registration deadline')
+
+
+class OrganizerEditDeadlineTest(TestCase):
+    """Organizer editing must not be blocked by the editing deadline (issue #124)."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username='owner', password='pw')
+        self.client.login(username='owner', password='pw')
+
+        # Close editing deadline
+        settings = EventSettings.get_solo()
+        settings.editing_deadline = timezone.now() - timedelta(hours=1)
+        settings.save()
+
+        self.organizer = _make_organizer(self.user)
+
+    def test_edit_organizer_allowed_after_editing_deadline(self):
+        url = reverse('SkaRe:edit_organizer', kwargs={'organizer_id': self.organizer.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/SkaRe/views/registration.py
+++ b/SkaRe/views/registration.py
@@ -572,12 +572,10 @@ def edit_individual_participant(request, participant_id):
 
 @login_required
 def register_organizer(request):
-    """View for registering a new Organizer."""
+    """View for registering a new Organizer.
 
-    # Check if registration is still open
-    if not EventSettings.is_registration_open():
-        messages.error(request, _('Registration is currently closed.'))
-        return redirect('SkaRe:home')
+    Organizer registration is not restricted by the registration deadline.
+    """
 
     if request.method == 'POST':
         if is_duplicate_submission(request):
@@ -620,7 +618,6 @@ def register_organizer(request):
 
     context = {
         'form': form,
-        'deadline': EventSettings.get_registration_deadline(),
         'form_token': request.session.get('form_token', ''),
     }
     return render(request, 'SkaRe/registration/register_organizer.html', context)
@@ -635,7 +632,6 @@ def list_organizers(request):
 
     context = {
         'organizers': organizers,
-        'editing_deadline': EventSettings.get_editing_deadline(),
     }
     return render(request, 'SkaRe/registration/list_organizers.html', context)
 
@@ -782,11 +778,6 @@ def edit_organizer(request, organizer_id):
     is_editor = organizer.entity.editors.filter(id=request.user.id).exists()
     if not (is_owner or is_editor):
         messages.error(request, _('You do not have permission to edit this organizer.'))
-        return redirect('SkaRe:list_organizers')
-
-    # Check if organizer can be edited
-    if not organizer.entity.can_be_edited(request.user):
-        messages.error(request, _('This organizer cannot be edited after the editing deadline.'))
         return redirect('SkaRe:list_organizers')
 
     # Define forms inline


### PR DESCRIPTION
## Summary

- Organizer registration is no longer blocked after the `registration_deadline`
- Organizer editing is no longer blocked after the `editing_deadline`
- Units and individual participants remain deadline-restricted as before
- Removed the deadline info banner from the organizer registration page and list

## Changes

- `register_organizer` view: removed `is_registration_open()` guard
- `edit_organizer` view: removed `can_be_edited()` deadline guard (ownership check kept)
- `list_organizers` view: removed `editing_deadline` from context
- New test file `SkaRe/tests/test_organizer_views.py` covering both cases
- `CLAUDE.md` updated to document the exemption

## Test plan

- [ ] `uv run manage.py test SkaRe.tests.test_organizer_views` — all 4 new tests pass
- [ ] `uv run manage.py test` — no regressions in existing test suite

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)