### PR TITLE
feat: add registration date column to manage entities table

### DIFF
--- a/SkaRe/templates/SkaRe/registration/manage_entities.html
+++ b/SkaRe/templates/SkaRe/registration/manage_entities.html
@@ -83,6 +83,7 @@
                             <th>{% trans "Type" %}</th>
                             <th>{% trans "Name" %}</th>
                             <th>{% trans "Created By" %}</th>
+                            <th>{% trans "Registered" %}</th>
                             <th class="text-center">{% trans "Paid" %}</th>
                             <th class="text-center">{% trans "Confirmed" %}</th>
                         </tr>
@@ -101,6 +102,7 @@
                             </td>
                             <td><strong>{{ item.name }}</strong></td>
                             <td>{{ item.entity.created_by.get_full_name|default:item.entity.created_by.username }}</td>
+                            <td>{{ item.entity.created_at|date:"d.m.Y H:i" }}</td>
                             <td class="text-center">
                                 <input type="hidden" name="entity_ids" value="{{ item.entity.id }}">
                                 <div class="form-check d-flex justify-content-center">
@@ -127,7 +129,7 @@
                         </tr>
                         {% empty %}
                         <tr>
-                            <td colspan="5" class="text-center">
+                            <td colspan="6" class="text-center">
                                 <div class="alert alert-warning mb-0">
                                     <i class="bi bi-exclamation-triangle"></i> {% trans "No results found." %}
                                 </div>


### PR DESCRIPTION
## Summary

- Adds a **Registered** column to the `/entities/manage/` table showing the `Entity.created_at` timestamp (formatted as `dd.mm.YYYY HH:MM`)
- The table was already ordered by registration date (newest first) — this just makes it visible
- No model changes or migrations needed; `created_at` already existed on `Entity`

Closes #122

## Test plan

- [ ] Visit `/entities/manage/` as staff user and verify the new "Registered" column appears between "Created By" and "Paid"
- [ ] Confirm timestamps display in `dd.mm.YYYY HH:MM` format
- [ ] Confirm empty-state row still spans the full table width

🤖 Generated with [Claude Code](https://claude.com/claude-code)