### PR TITLE
fix: persist ticket nav buttons across all sub-pages (closes #121)

### DIFF
--- a/SkaRe/templates/SkaRe/tickets/_nav.html
+++ b/SkaRe/templates/SkaRe/tickets/_nav.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+<div class="mb-3 d-flex gap-2 flex-wrap">
+  <a href="{% url 'SkaRe:infodesk_dashboard' %}" class="btn btn-outline-secondary btn-sm">
+    <i class="bi bi-arrow-left"></i> {% trans "Dashboard" %}
+  </a>
+  <a href="{% url 'SkaRe:ticket_list' %}" class="btn btn-outline-secondary btn-sm">
+    <i class="bi bi-ticket-perforated"></i> {% trans "All tickets" %}
+  </a>
+  <a href="{% url 'SkaRe:ticket_lookup' %}" class="btn btn-outline-primary btn-sm">
+    <i class="bi bi-search"></i> {% trans "Quick lookup" %}
+  </a>
+  <a href="{% url 'SkaRe:ticket_create_bulk' %}" class="btn btn-outline-success btn-sm">
+    <i class="bi bi-plus-circle"></i> {% trans "Bulk create" %}
+  </a>
+  <a href="{% url 'SkaRe:ticket_on_water' %}" class="btn btn-outline-danger btn-sm">
+    <i class="bi bi-water"></i> {% trans "On water" %}
+  </a>
+  <a href="{% url 'SkaRe:ticket_export_csv' %}" class="btn btn-outline-dark btn-sm">
+    <i class="bi bi-download"></i> {% trans "Export CSV" %}
+  </a>
+</div>

--- a/SkaRe/templates/SkaRe/tickets/create_bulk.html
+++ b/SkaRe/templates/SkaRe/tickets/create_bulk.html
@@ -5,9 +5,7 @@
 
 {% block content %}
 <h1 class="mb-3"><i class="bi bi-plus-circle"></i> {% trans "Bulk Create Sail Tickets" %}</h1>
-<a href="{% url 'SkaRe:ticket_list' %}" class="btn btn-outline-secondary btn-sm mb-3">
-  <i class="bi bi-arrow-left"></i> {% trans "All tickets" %}
-</a>
+{% include 'SkaRe/tickets/_nav.html' %}
 
 {% if plan %}
 {# ── Preview / confirmation mode ── #}

--- a/SkaRe/templates/SkaRe/tickets/detail.html
+++ b/SkaRe/templates/SkaRe/tickets/detail.html
@@ -6,11 +6,7 @@
 {% block content %}
 <h1 class="mb-2">{{ ticket.code }}</h1>
 <p class="text-muted">{{ ticket.get_color_display }}</p>
-<div class="mb-3 d-flex gap-2">
-  <a href="{% url 'SkaRe:ticket_list' %}" class="btn btn-outline-secondary btn-sm">
-    <i class="bi bi-arrow-left"></i> {% trans "All tickets" %}
-  </a>
-</div>
+{% include 'SkaRe/tickets/_nav.html' %}
 
 {% if messages %}
   {% for msg in messages %}

--- a/SkaRe/templates/SkaRe/tickets/list.html
+++ b/SkaRe/templates/SkaRe/tickets/list.html
@@ -5,23 +5,7 @@
 
 {% block content %}
 <h1 class="mb-3"><i class="bi bi-ticket-perforated"></i> {% trans "Sail Tickets" %}</h1>
-<div class="mb-3 d-flex gap-2">
-  <a href="{% url 'SkaRe:infodesk_dashboard' %}" class="btn btn-outline-secondary btn-sm">
-    <i class="bi bi-arrow-left"></i> {% trans "Dashboard" %}
-  </a>
-  <a href="{% url 'SkaRe:ticket_lookup' %}" class="btn btn-primary btn-sm">
-    <i class="bi bi-search"></i> {% trans "Quick lookup" %}
-  </a>
-  <a href="{% url 'SkaRe:ticket_create_bulk' %}" class="btn btn-outline-success btn-sm">
-    <i class="bi bi-plus-circle"></i> {% trans "Bulk create" %}
-  </a>
-  <a href="{% url 'SkaRe:ticket_on_water' %}" class="btn btn-outline-danger btn-sm">
-    <i class="bi bi-water"></i> {% trans "On water" %}
-  </a>
-  <a href="{% url 'SkaRe:ticket_export_csv' %}" class="btn btn-outline-dark btn-sm">
-    <i class="bi bi-download"></i> {% trans "Export CSV" %}
-  </a>
-</div>
+{% include 'SkaRe/tickets/_nav.html' %}
 
 <form class="row g-2 mb-3" method="get">
   <div class="col-auto">

--- a/SkaRe/templates/SkaRe/tickets/lookup.html
+++ b/SkaRe/templates/SkaRe/tickets/lookup.html
@@ -5,9 +5,7 @@
 
 {% block content %}
 <h1 class="mb-3"><i class="bi bi-search"></i> {% trans "Ticket Quick Lookup" %}</h1>
-<a href="{% url 'SkaRe:infodesk_dashboard' %}" class="btn btn-outline-secondary btn-sm mb-3">
-  <i class="bi bi-arrow-left"></i> {% trans "Dashboard" %}
-</a>
+{% include 'SkaRe/tickets/_nav.html' %}
 <form method="get" class="mb-4">
   <div class="input-group">
     <input type="text" name="q" value="{{ query }}" class="form-control form-control-lg"

--- a/SkaRe/templates/SkaRe/tickets/on_water.html
+++ b/SkaRe/templates/SkaRe/tickets/on_water.html
@@ -6,10 +6,8 @@
 {% block content %}
 <h1 class="mb-3"><i class="bi bi-water"></i> {% trans "Boats Currently on Water" %}</h1>
 <p class="text-muted">{% trans "Safety view — refreshed on load." %}</p>
-<div class="mb-3 d-flex gap-2">
-  <a href="{% url 'SkaRe:infodesk_dashboard' %}" class="btn btn-outline-secondary btn-sm">
-    <i class="bi bi-arrow-left"></i> {% trans "Dashboard" %}
-  </a>
+{% include 'SkaRe/tickets/_nav.html' %}
+<div class="mb-3">
   <a href="{{ request.path }}" class="btn btn-primary btn-sm">
     <i class="bi bi-arrow-clockwise"></i> {% trans "Refresh" %}
   </a>


### PR DESCRIPTION
## Summary

- Extracted the ticket section navigation into a shared `SkaRe/tickets/_nav.html` partial
- Included it in all ticket sub-pages: list, lookup, on_water, detail, create_bulk
- All nav buttons (Dashboard, All tickets, Quick lookup, Bulk create, On water, Export CSV) are now always visible regardless of which sub-page the user is on
- The "On water" page retains its page-specific Refresh button below the shared nav

## Test plan

- [x] All 34 ticket view tests pass
- [ ] Navigate to Sail Tickets list → click Quick lookup → nav buttons still visible
- [ ] Navigate to On water → nav buttons visible + Refresh button present
- [ ] Navigate to a ticket detail → nav buttons visible
- [ ] Navigate to Bulk create → nav buttons visible

Fixes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)